### PR TITLE
list_accounts generator added to SteemNodeRPC

### DIFF
--- a/steemapi/steemnoderpc.py
+++ b/steemapi/steemnoderpc.py
@@ -174,3 +174,28 @@ class SteemNodeRPC(GrapheneWebsocketRPC):
                 for op in tx["operations"]:
                     if op[0] in opNames:
                         yield op[1]
+
+    def list_accounts(self, start=None, step=1000, limit=None):
+        """ Yield list of user accounts in alphabetical order
+
+        :param str start: Name of account, which should be yield first
+        :param int step: Describes how many accounts should be fetched in each rpc request
+        :param int limit: Limit number of returned user accounts
+        """
+        if limit and limit < step:
+            step = limit
+
+        fetched_users = 0
+        progress = step
+
+        while progress == step and (not limit or fetched_users < limit):
+            users = self.lookup_accounts(start, step)
+            progress = len(users)
+
+            if progress > 0:
+                yield from users
+                fetched_users += progress
+
+                # concatenate last fetched account name with lowest possible
+                # ascii character to get next lowest possible login as lower_bound
+                start = users[-1] + '\0'

--- a/steemapi/steemnoderpc.py
+++ b/steemapi/steemnoderpc.py
@@ -185,16 +185,16 @@ class SteemNodeRPC(GrapheneWebsocketRPC):
         if limit and limit < step:
             step = limit
 
-        fetched_users = 0
+        number_of_fetched_users = 0
         progress = step
 
-        while progress == step and (not limit or fetched_users < limit):
+        while progress == step and (not limit or number_of_fetched_users < limit):
             users = self.lookup_accounts(start, step)
             progress = len(users)
 
             if progress > 0:
                 yield from users
-                fetched_users += progress
+                number_of_fetched_users += progress
 
                 # concatenate last fetched account name with lowest possible
                 # ascii character to get next lowest possible login as lower_bound


### PR DESCRIPTION
Implementation of first item from https://github.com/xeroc/piston/issues/50

Example of use:

```
# fetch all items, 1000 items per request
rpc.list_accounts()

# first 100 accounts in alphabetical order
rpc.list_accounts(limit=100)

# request for 10 items, starting from 'noisy'
rpc.list_accounts(start='noisy', limit=10)

# first 50000 items, fetched by 500 per request
rpc.list_accounts(step=500, limit=50000)
```
