### PR TITLE
Fix wallet 'skipcreatewallet' option

### DIFF
--- a/steem/wallet.py
+++ b/steem/wallet.py
@@ -255,7 +255,6 @@ class Wallet():
         for a in accounts:
             if a["name"] == account:
                 self.removePrivateKeyFromPublicKey(a["pubkey"])
-                break
 
     def getOwnerKeyForAccount(self, name):
         """ Obtain owner Private Key for an account from the wallet database

--- a/steem/wallet.py
+++ b/steem/wallet.py
@@ -245,6 +245,8 @@ class Wallet():
         """
         if self.keyStorage:
             self.keyStorage.delete(pub)
+        else:
+            del self.keys[pub]
 
     def removeAccount(self, account):
         """ Remove all keys associated with a given account
@@ -253,6 +255,7 @@ class Wallet():
         for a in accounts:
             if a["name"] == account:
                 self.removePrivateKeyFromPublicKey(a["pubkey"])
+                break
 
     def getOwnerKeyForAccount(self, name):
         """ Obtain owner Private Key for an account from the wallet database

--- a/steem/wallet.py
+++ b/steem/wallet.py
@@ -66,13 +66,13 @@ class Wallet():
             """ If no keys are provided manually we load the SQLite
                 keyStorage
             """
-            from .storage import (keyStorage,
-                                  MasterPassword,
-                                  configStorage)
-            self.configStorage = configStorage
-            self.MasterPassword = MasterPassword
-            self.keyStorage = keyStorage
             if not self.created() and not kwargs.get("skipcreatewallet", False):
+                from .storage import (keyStorage,
+                                      MasterPassword,
+                                      configStorage)
+                self.configStorage = configStorage
+                self.MasterPassword = MasterPassword
+                self.keyStorage = keyStorage
                 self.newWallet()
 
     def setKeys(self, loadkeys):


### PR DESCRIPTION
Fixed a bug where you cannot add keys in memory when an steem object have created with "skipcreatewallet" and without "keys".

Example: I want to create Steem object without keys, but I want later add keys in memory. I use special key "skipcreatewallet". And after that I add keys like this:
```
steem = Steem()
steem.wallet.setKeys('key')
```
And after that I want use steem object to vote from several account. But it do not work due configStorage and etc. sets before "skipcreatewallet".

Proof:
```
steem = Steem(skipcreatewallet=True)
print(steem.wallet.getPublicKeys())
steem.wallet.setKeys('key')
print(steem.wallet.getPublicKeys())
print(steem.wallet.getPostingKeyForAccount('account'))

steem = Steem(skipcreatewallet=True)
del steem.wallet.keyStorage
del steem.wallet.configStorage
del steem.wallet.MasterPassword
print(steem.wallet.getPublicKeys())
steem.wallet.setKeys('key')
print(steem.wallet.getPublicKeys())
print(steem.wallet.getPostingKeyForAccount('account'))
```