### PR TITLE
Added basic beneficiaries support during post creation.

### DIFF
--- a/piston/post.py
+++ b/piston/post.py
@@ -288,6 +288,8 @@ class Post(dict):
                    options.get("allow_votes", self["allow_votes"]),
                "allow_curation_rewards":
                    options.get("allow_curation_rewards", self["allow_curation_rewards"]),
+                "extensions":
+                   options.get("extensions", []),
                }
         )
         return self.steem.finalizeOp(op, self["author"], "posting")

--- a/piston/steem.py
+++ b/piston/steem.py
@@ -364,6 +364,8 @@ class Steem(object):
             options["allow_votes"] = meta.pop("allow_votes", None)
         if "allow_curation_rewards" in meta:
             options["allow_curation_rewards"] = meta.pop("allow_curation_rewards", None)
+        if "extensions" in meta:
+            options["extensions"] = meta.pop("extensions", [])
 
         # deal with the category and tags
         if isinstance(tags, str):

--- a/piston/steem.py
+++ b/piston/steem.py
@@ -422,7 +422,8 @@ class Steem(object):
                         options.get("percent_steem_dollars", 100) * STEEMIT_1_PERCENT
                     ),
                     "allow_votes": options.get("allow_votes", True),
-                    "allow_curation_rewards": options.get("allow_curation_rewards", True)}))
+                    "allow_curation_rewards": options.get("allow_curation_rewards", True),
+                    "extensions": options.get("extensions", [])}))
 
         return self.finalizeOp(op, author, "posting")
 


### PR DESCRIPTION
We have Commen_options object with support of steem beneficiaries but we are currently unable to use this functionality during the post creation. This pull-request fixes that issue. 