### PR TITLE
Fix blocks to use "stop" param

### DIFF
--- a/piston/blockchain.py
+++ b/piston/blockchain.py
@@ -108,6 +108,9 @@ class Blockchain(object):
 
             # Get chain properies to identify the
             head_block = self.get_current_block_num()
+            
+            if(stop):
+                head_block = min(stop, head_block)
 
             # Blocks from start until head block
             for blocknum in range(start, head_block + 1):


### PR DESCRIPTION
blocks took "stop" parameter into account only when it was greater than self.get_current_block_num()