### PR TITLE
Fix return arg in get_block_from_time()

### DIFF
--- a/piston/blockchain.py
+++ b/piston/blockchain.py
@@ -287,7 +287,7 @@ class Blockchain(object):
             guess_block += error / 3
             guess_block_timestamp = self.block_timestamp(guess_block)
             error = timestring_timestamp - guess_block_timestamp
-        return int(guess_block.block)
+        return int(guess_block)
 
     def get_all_accounts(self, start='', stop='', steps=1e6, **kwargs):
         """ Yields account names between start and stop.


### PR DESCRIPTION
guess_block is already .block.

Fixes an error:
```
Traceback (most recent call last):
  File "./block_test.py", line 18, in <module>
    start_block = chain.get_block_from_time(created)
  File "/home/vvk/devel/golos/piston/venv/lib/python3.4/site-packages/piston/blockchain.py", line 271, in get_block_from_time
    return int(guess_block.block)
AttributeError: 'float' object has no attribute 'block'
```