### PR TITLE
Pass prefix to PublicKey() in witness_update()

### DIFF
--- a/piston/steem.py
+++ b/piston/steem.py
@@ -907,7 +907,7 @@ class Steem(object):
             raise ValueError("You need to provide an account")
 
         try:
-            PublicKey(signing_key)
+            PublicKey(signing_key, prefix=self.rpc.chain_params["prefix"])
         except Exception as e:
             raise e
 


### PR DESCRIPTION
This fixes the following error with golos:

```
Traceback (most recent call last):
  File "./update_witness.py", line 69, in <module>
    main()
  File "./update_witness.py", line 66, in main
    update_witness(golos, pubkey, conf['url'], conf['props'], conf['witness'])
  File "./update_witness.py", line 19, in update_witness
    raise e
  File "./update_witness.py", line 16, in update_witness
    steem_instance.witness_update(signing_key, url, props, account=account)
  File "/home/vvk/devel/golos/golos-witness-tools/venv/lib/python3.4/site-packages/piston/steem.py", line 912, in witness_update
    raise e
  File "/home/vvk/devel/golos/golos-witness-tools/venv/lib/python3.4/site-packages/piston/steem.py", line 910, in witness_update
    PublicKey(signing_key)
  File "/home/vvk/devel/golos/golos-witness-tools/venv/lib/python3.4/site-packages/pistonbase/account.py", line 79, in __init__
    super(PublicKey, self).__init__(pk, prefix)
  File "/home/vvk/devel/golos/golos-witness-tools/venv/lib/python3.4/site-packages/graphenebase/account.py", line 216, in __init__
    self._pk = Base58(pk, prefix=prefix)
  File "/home/vvk/devel/golos/golos-witness-tools/venv/lib/python3.4/site-packages/graphenebase/base58.py", line 60, in __init__
    raise ValueError("Error loading Base58 object")
ValueError: Error loading Base58 object
```