### PR TITLE
Fix memo encryption and decryption for non-steem networks

### DIFF
--- a/piston/steem.py
+++ b/piston/steem.py
@@ -1067,7 +1067,7 @@ class Steem(object):
         """ Try to decode an encrypted memo
         """
         assert enc_memo[0] == "#", "decode memo requires memos to start with '#'"
-        keys = memo.involved_keys(enc_memo)
+        keys = memo.involved_keys(enc_memo, prefix=self.rpc.chain_params["prefix"])
         wif = None
         for key in keys:
             wif = self.wallet.getPrivateKeyForPublicKey(str(key))

--- a/pistonbase/memo.py
+++ b/pistonbase/memo.py
@@ -152,11 +152,11 @@ def decode_memo(priv, message):
         raise ValueError(message)
 
 
-def involved_keys(message):
+def involved_keys(message, prefix=default_prefix):
     " decode structure "
     raw = base58decode(message[1:])
-    from_key = PublicKey(raw[:66])
+    from_key = PublicKey(raw[:66], prefix=prefix)
     raw = raw[66:]
-    to_key = PublicKey(raw[:66])
+    to_key = PublicKey(raw[:66], prefix=prefix)
 
     return [from_key, to_key]

--- a/pistonbase/memo.py
+++ b/pistonbase/memo.py
@@ -99,6 +99,7 @@ def encode_memo(priv, pub, nonce, message, **kwargs):
         "from_priv": repr(priv),
         "to_pub": repr(pub),
         "shared_secret": shared_secret,
+        "prefix": prefix,
     }
     tx = transactions.Memo(**s)
     return "#" + base58encode(hexlify(bytes(tx)).decode("ascii"))


### PR DESCRIPTION
Fixes following error:

```
Traceback (most recent call last):
  File "./transfer.py", line 18, in transfer
    steem_instance.transfer(to, amount, asset, memo=memo, account=account)
  File "/home/vvk/devel/golos/golos-scripts/venv/lib/python3.6/site-packages/piston/steem.py", line 673, in transfer
    prefix=self.rpc.chain_params["prefix"]
  File "/home/vvk/devel/golos/golos-scripts/venv/lib/python3.6/site-packages/pistonbase/memo.py", line 104, in encode_memo
    tx = transactions.Memo(**s)
  File "/home/vvk/devel/golos/golos-scripts/venv/lib/python3.6/site-packages/pistonbase/operations.py", line 108, in __init__
    ('from', PublicKey(kwargs["from"], prefix=prefix)),
  File "/home/vvk/devel/golos/golos-scripts/venv/lib/python3.6/site-packages/graphenebase/account.py", line 216, in __init__
    self._pk = Base58(pk, prefix=prefix)
  File "/home/vvk/devel/golos/golos-scripts/venv/lib/python3.6/site-packages/graphenebase/base58.py", line 62, in __init__
    raise ValueError("Error loading Base58 object")
ValueError: Error loading Base58 object
```