### PR TITLE
setup.py: use pycryptodome instad of pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
         "diff-match-patch>=20121119",
         "appdirs>=1.4.0",
         "python-frontmatter>=0.2.1",
-        "pycrypto>=2.6.1",
         "funcy",
         "python-dateutil>=2.6.1",
+        "pycryptodome"
         # "python-dateutil",
         # "secp256k1==0.13.2"
     ],


### PR DESCRIPTION
Should fix

Traceback (most recent call last):
  File "/opt/code/telegram.py", line 16, in <module>
    from piston import Steem
  File "/usr/local/lib/python3.6/site-packages/piston/__init__.py", line 1, in <module>
    from .steem import Steem
  File "/usr/local/lib/python3.6/site-packages/piston/steem.py", line 9, in <module>
    from pistonbase import memo
  File "/usr/local/lib/python3.6/site-packages/pistonbase/memo.py", line 4, in <module>
    from Crypto.Cipher import AES
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/__init__.py", line 3, in <module>
    from Crypto.Cipher._mode_ecb import _create_ecb_cipher
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/_mode_ecb.py", line 29, in <module>
    from Crypto.Util._raw_api import (load_pycryptodome_raw_lib,
  File "/usr/local/lib/python3.6/site-packages/Crypto/Util/_raw_api.py", line 32, in <module>
    from Crypto.Util.py3compat import byte_string
ImportError: cannot import name 'byte_string'